### PR TITLE
Disable setup-gradle Enhanced Caching and delegate to setup-java

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,12 +13,15 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: |
             11
             21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
       - name: Check
         run: ./gradlew check
         env:

--- a/.github/workflows/releaseExtension.yml
+++ b/.github/workflows/releaseExtension.yml
@@ -13,12 +13,15 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: |
             11
             21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
       - name: Build Zip
         run: ./gradlew hivemqExtensionZip
       - name: Generate SHA256 checksum


### PR DESCRIPTION
## Summary

- Disable `setup-gradle` proprietary Enhanced Caching (`cache-disabled: true`) across all workflows
- Delegate caching to `setup-java` with `cache: gradle` (MIT-licensed, writes on all branches)

Tracked by [INT-247](https://linear.app/hivemq/issue/INT-247)